### PR TITLE
The most robust fix is to add an underscore alias in pyproject.toml s…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
 
 [project.scripts]
 first-agentic-csa = "wpilib_mcp.server:main"
+first_agentic_csa = "wpilib_mcp.server:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
…o both first-agentic-csa and first_agentic_csa work. This is a common Python packaging pitfall (hyphens vs underscores), and your dev-release.yml already does the same thing for the dev build.

Done. Now both first-agentic-csa and first_agentic_csa will resolve to the same entry point. Run uv sync to regenerate the scripts, and the server should start without the error.